### PR TITLE
Add Spring Boot RAG explorer skeleton

### DIFF
--- a/spring-app/README.md
+++ b/spring-app/README.md
@@ -1,0 +1,39 @@
+# Spring Boot GitHub RAG Explorer
+
+This module provides a Spring Boot implementation of the GitHub RAG Explorer.
+It demonstrates how to ingest GitHub repository content, store simple metadata
+and interact with a Large Language Model through Spring AI.
+
+## Features
+
+* Fetch repository contents using the `org.kohsuke:github-api` library.
+* Generate embeddings with Spring AI's `EmbeddingClient` and persist them with
+  Spring Data JPA.
+* Query documents and generate answers with Spring AI's `ChatClient`.
+* Simple Thymeleaf web UI for submitting questions and displaying results.
+
+## Requirements
+
+* Java 21
+* Maven 3.9+
+* PostgreSQL database
+* API keys for OpenAI and GitHub (via environment variables `OPENAI_API_KEY`
+  and `GITHUB_TOKEN`).
+
+## Running
+
+```
+cd spring-app
+mvn spring-boot:run
+```
+
+The application will start on [http://localhost:8080](http://localhost:8080).
+
+## Testing
+
+```
+cd spring-app
+mvn test
+```
+
+The tests use mocked AI clients and an in-memory database.

--- a/spring-app/pom.xml
+++ b/spring-app/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>github-rag-explorer</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>github-rag-explorer</name>
+    <description>RAG Explorer for GitHub repositories using Spring Boot and Spring AI</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+            <version>1.0.0-M1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.321</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-app/src/main/java/com/example/githubrag/GithubRagExplorerApplication.java
+++ b/spring-app/src/main/java/com/example/githubrag/GithubRagExplorerApplication.java
@@ -1,0 +1,11 @@
+package com.example.githubrag;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GithubRagExplorerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GithubRagExplorerApplication.class, args);
+    }
+}

--- a/spring-app/src/main/java/com/example/githubrag/controller/SearchController.java
+++ b/spring-app/src/main/java/com/example/githubrag/controller/SearchController.java
@@ -1,0 +1,41 @@
+package com.example.githubrag.controller;
+
+import java.util.List;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import com.example.githubrag.dto.SearchRequest;
+import com.example.githubrag.dto.SearchResult;
+import com.example.githubrag.model.RepositoryDocument;
+import com.example.githubrag.service.RagService;
+import com.example.githubrag.repository.RepositoryDocumentRepository;
+
+@Controller
+public class SearchController {
+
+    private final RagService ragService;
+    private final RepositoryDocumentRepository repository;
+
+    public SearchController(RagService ragService, RepositoryDocumentRepository repository) {
+        this.ragService = ragService;
+        this.repository = repository;
+    }
+
+    @GetMapping("/")
+    public String index(Model model) {
+        model.addAttribute("request", new SearchRequest());
+        return "index";
+    }
+
+    @PostMapping("/search")
+    public String search(@ModelAttribute("request") SearchRequest request, Model model) {
+        String answer = ragService.chat(request.getQuery());
+        List<RepositoryDocument> docs = repository.findTop5ByOrderByIdAsc();
+        model.addAttribute("result", new SearchResult(answer, docs));
+        return "index";
+    }
+}

--- a/spring-app/src/main/java/com/example/githubrag/dto/SearchRequest.java
+++ b/spring-app/src/main/java/com/example/githubrag/dto/SearchRequest.java
@@ -1,0 +1,8 @@
+package com.example.githubrag.dto;
+
+import lombok.Data;
+
+@Data
+public class SearchRequest {
+    private String query;
+}

--- a/spring-app/src/main/java/com/example/githubrag/dto/SearchResult.java
+++ b/spring-app/src/main/java/com/example/githubrag/dto/SearchResult.java
@@ -1,0 +1,15 @@
+package com.example.githubrag.dto;
+
+import java.util.List;
+
+import com.example.githubrag.model.RepositoryDocument;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SearchResult {
+    private String answer;
+    private List<RepositoryDocument> documents;
+}

--- a/spring-app/src/main/java/com/example/githubrag/model/RepositoryDocument.java
+++ b/spring-app/src/main/java/com/example/githubrag/model/RepositoryDocument.java
@@ -1,0 +1,26 @@
+package com.example.githubrag.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+import lombok.Data;
+
+@Data
+@Entity
+public class RepositoryDocument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String path;
+
+    @Lob
+    private String content;
+
+    @Lob
+    private String embedding;
+}

--- a/spring-app/src/main/java/com/example/githubrag/repository/RepositoryDocumentRepository.java
+++ b/spring-app/src/main/java/com/example/githubrag/repository/RepositoryDocumentRepository.java
@@ -1,0 +1,11 @@
+package com.example.githubrag.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.githubrag.model.RepositoryDocument;
+
+public interface RepositoryDocumentRepository extends JpaRepository<RepositoryDocument, Long> {
+    List<RepositoryDocument> findTop5ByOrderByIdAsc();
+}

--- a/spring-app/src/main/java/com/example/githubrag/service/GithubService.java
+++ b/spring-app/src/main/java/com/example/githubrag/service/GithubService.java
@@ -1,0 +1,48 @@
+package com.example.githubrag.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GithubService {
+
+    private final GitHub github;
+
+    public GithubService(@Value("${github.token:}") String token) throws IOException {
+        if (token != null && !token.isBlank()) {
+            this.github = new GitHubBuilder().withOAuthToken(token).build();
+        } else {
+            this.github = GitHubBuilder.fromEnvironment().build();
+        }
+    }
+
+    public List<RepositoryFile> fetchRepository(String owner, String repo) throws IOException {
+        GHRepository repository = github.getRepository(owner + "/" + repo);
+        List<RepositoryFile> files = new ArrayList<>();
+        for (GHContent content : repository.getDirectoryContent("/")) {
+            traverse(content, files);
+        }
+        return files;
+    }
+
+    private void traverse(GHContent content, List<RepositoryFile> files) throws IOException {
+        if (content.isFile()) {
+            files.add(new RepositoryFile(content.getPath(), content.getContent()));
+        } else if (content.isDirectory()) {
+            for (GHContent c : content.listDirectoryContent()) {
+                traverse(c, files);
+            }
+        }
+    }
+
+    public record RepositoryFile(String path, String content) {
+    }
+}

--- a/spring-app/src/main/java/com/example/githubrag/service/IndexingService.java
+++ b/spring-app/src/main/java/com/example/githubrag/service/IndexingService.java
@@ -1,0 +1,37 @@
+package com.example.githubrag.service;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.stereotype.Service;
+
+import com.example.githubrag.model.RepositoryDocument;
+import com.example.githubrag.repository.RepositoryDocumentRepository;
+
+@Service
+public class IndexingService {
+
+    private final GithubService githubService;
+    private final RepositoryDocumentRepository repository;
+    private final EmbeddingClient embeddingClient;
+
+    public IndexingService(GithubService githubService, RepositoryDocumentRepository repository,
+            EmbeddingClient embeddingClient) {
+        this.githubService = githubService;
+        this.repository = repository;
+        this.embeddingClient = embeddingClient;
+    }
+
+    public void indexRepository(String owner, String repo) throws IOException {
+        List<GithubService.RepositoryFile> files = githubService.fetchRepository(owner, repo);
+        for (GithubService.RepositoryFile file : files) {
+            List<Double> embedding = embeddingClient.embed(file.content());
+            RepositoryDocument doc = new RepositoryDocument();
+            doc.setPath(file.path());
+            doc.setContent(file.content());
+            doc.setEmbedding(embedding.toString());
+            repository.save(doc);
+        }
+    }
+}

--- a/spring-app/src/main/java/com/example/githubrag/service/RagService.java
+++ b/spring-app/src/main/java/com/example/githubrag/service/RagService.java
@@ -1,0 +1,40 @@
+package com.example.githubrag.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.stereotype.Service;
+
+import com.example.githubrag.model.RepositoryDocument;
+import com.example.githubrag.repository.RepositoryDocumentRepository;
+
+@Service
+public class RagService {
+
+    private final RepositoryDocumentRepository repository;
+    private final ChatClient chatClient;
+
+    public RagService(RepositoryDocumentRepository repository, ChatClient chatClient) {
+        this.repository = repository;
+        this.chatClient = chatClient;
+    }
+
+    public String chat(String question) {
+        List<RepositoryDocument> docs = repository.findTop5ByOrderByIdAsc();
+        String context = docs.stream().map(RepositoryDocument::getContent)
+                .collect(Collectors.joining("\n---\n"));
+        PromptTemplate template = new PromptTemplate("""
+                Answer the user's question using the following repository context.
+
+                {context}
+
+                Question: {question}
+                """);
+        Prompt prompt = template.create(Map.of("context", context, "question", question));
+        return chatClient.call(prompt).getResult().getOutput().getContent();
+    }
+}

--- a/spring-app/src/main/resources/application.yml
+++ b/spring-app/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/rag
+    username: rag
+    password: rag
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY:}
+      chat:
+        model: gpt-3.5-turbo
+      embedding:
+        model: text-embedding-3-small
+
+github:
+  token: ${GITHUB_TOKEN:}

--- a/spring-app/src/main/resources/templates/index.html
+++ b/spring-app/src/main/resources/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>GitHub RAG Explorer</title>
+</head>
+<body>
+<h1>Repository Search</h1>
+<form th:action="@{/search}" th:object="${request}" method="post">
+    <input type="text" th:field="*{query}" placeholder="Ask a question" />
+    <button type="submit">Search</button>
+</form>
+<div th:if="${result}">
+    <h2>Answer</h2>
+    <p th:text="${result.answer}"></p>
+    <h3>Documents</h3>
+    <ul>
+        <li th:each="doc : ${result.documents}">
+            <strong th:text="${doc.path}"></strong>
+            <pre th:text="${doc.content}"></pre>
+        </li>
+    </ul>
+</div>
+</body>
+</html>

--- a/spring-app/src/test/java/com/example/githubrag/SearchControllerTest.java
+++ b/spring-app/src/test/java/com/example/githubrag/SearchControllerTest.java
@@ -1,0 +1,48 @@
+package com.example.githubrag;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.githubrag.controller.SearchController;
+import com.example.githubrag.model.RepositoryDocument;
+import com.example.githubrag.repository.RepositoryDocumentRepository;
+import com.example.githubrag.service.RagService;
+
+@WebMvcTest(SearchController.class)
+class SearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RagService ragService;
+
+    @MockBean
+    private RepositoryDocumentRepository repository;
+
+    @Test
+    void indexShouldReturnForm() throws Exception {
+        mockMvc.perform(get("/")).andExpect(status().isOk()).andExpect(view().name("index"));
+    }
+
+    @Test
+    void searchShouldReturnResult() throws Exception {
+        when(ragService.chat("test")).thenReturn("answer");
+        when(repository.findTop5ByOrderByIdAsc()).thenReturn(List.of());
+        mockMvc.perform(post("/search").param("query", "test"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("result"));
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Spring Boot 3 project with Web, Thymeleaf, Spring AI, JPA, and GitHub API
- implement services for GitHub ingestion, embedding, RAG chat, and basic search UI
- add Thymeleaf template, DTOs, and controller along with README and tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for com.example:github-rag-explorer)*

------
https://chatgpt.com/codex/tasks/task_e_68a39ae3df648325a4ed732521d67712